### PR TITLE
Force Interface List and Accesspoint List refresh on call to CPosixNetwo...

### DIFF
--- a/xbmc/network/linux/PosixNetworkManager.cpp
+++ b/xbmc/network/linux/PosixNetworkManager.cpp
@@ -123,6 +123,11 @@ bool CPosixNetworkManager::CanManageConnections()
 
 ConnectionList CPosixNetworkManager::GetConnections()
 {
+  FindNetworkInterfaces(); 
+  if (CanManageConnections())
+    RestoreSavedConnection();
+  else
+    RestoreSystemConnection();
   return m_connections;
 }
 


### PR DESCRIPTION
...rkManager:GetConnection

This should fix two Problems
1) Under normal conditions XBMC never refreshes its list of network interfaces once it start running.  So if you plug in a USB network adapter (wireless, wired or tcp over bluetooth) xbmc doesn't see it.
2) XBMC won't refresh the list of access points, strengths, etc  "if" you already have an existing connection to something.

Seems that XBMC never refreshes the list of access points or its list of network interfaces after application starts unless there is a connection state change.  This means if you reposition your access point, change channel on AP, or change encryption type its not reflected in interface display in XBMC.  Current model for updating the m_connection is all event driven, but doesn't refresh list unless connection state changes.
This patch causes FindNetworkInterfaces to be called each time GetConnections is called, which refreshes interface list (in case they changed) and refreshes AP list.  This might be a slightly heavy handed way to do it, but can't see any other way to address both problem.
