### PR TITLE
Allow Powerdown menu for devices other than M1

### DIFF
--- a/xbmc/powermanagement/linux/PivosPowerSyscall.cpp
+++ b/xbmc/powermanagement/linux/PivosPowerSyscall.cpp
@@ -32,7 +32,7 @@ CPivosPowerSyscall::CPivosPowerSyscall()
   }
   else
   {
-    m_CanPowerdown = false;
+    m_CanPowerdown = true;
     m_CanSuspend   = true;
   }
   m_CanHibernate = false;


### PR DESCRIPTION
This is the corresponding modification to XBMC to renable shutdown option for M3.  Will only be necessary if you should to merge in the pull request to buildroot at:
https://github.com/Pivosgroup/buildroot-linux/pull/51

This renables Powerdown menu so S95-xbmc script has a chance to run and dismount drives and removable media.

On M3 users will have to physically remove power to power off.
