### PR TITLE
Bug-Fix: Add packet-fps-change-detection for PVRClient (solves missing hints.fps*)

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
@@ -275,6 +275,16 @@ void CDVDDemuxPVRClient::ParsePacket(DemuxPacket* pkt)
         CDemuxStreamVideoPVRClient* stv = static_cast<CDemuxStreamVideoPVRClient*>(st);
         CHECK_UPDATE(stv, iWidth        , pvr->m_context->width , 0);
         CHECK_UPDATE(stv, iHeight       , pvr->m_context->height, 0);
+
+        if((pkt->duration > 0) && (pkt->duration != stv->iFpsScale))
+        {
+          CLog::Log(LOGDEBUG, "%s - {%d} iFpsScale changed from %d to %d",  __FUNCTION__, stv->iId, stv->iFpsScale, pkt->duration);
+          stv->iFpsScale = pkt->duration;
+          CLog::Log(LOGDEBUG, "%s - {%d} iFpsRate changed from %d to %d",  __FUNCTION__, stv->iId, stv->iFpsRate, DVD_TIME_BASE);
+          stv->iFpsRate = DVD_TIME_BASE;
+          stv->changes += 2;
+          stv->disabled = false;
+        }
         break;
       }
 


### PR DESCRIPTION
Hi,

finally I've found the location in the function chain, where the hints.fps\* get lost.

Tvheadend doesn't seem to be able, to deliver the hints (iFPSScale, iFPSRate, iChannels & iSampleRate) at subscription start. This will be done with the next packets, which will be received by the HTSP client. But unfortunately the demuxer of the PVR stream doesn't forward this information (iFPSScale & iFPSRate) to the video codecs, so they have to do this with their own workarounds.
With this patch this information will be forwarded and the stream and codec will be re-opened, so the AMLCodec has the new/modified hints from the beginning.

Unfortunately this wouldn't fix the crappy/choppy DVB playback yet, but this seems to be connected to the audio stream, where the data will be requested to fast or the stream wouldn't be delivered in time:
"CSoftAEStream::GetFrame - Underrun" followed by "CSoftAEStream::Flush".

@davilla:
It would be great, if you could do a PR to the upstream xbmc (I think, they will trust you more than me ;D).

Regards, JK
