### PR TITLE
[atv] added maxplayerforwardrate to advanced_settings

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2783,7 +2783,7 @@ bool CApplication::OnAction(const CAction &action)
 
         if (action.GetID() == ACTION_PLAYER_FORWARD && iPlaySpeed == -1) //sets iSpeed back to 1 if -1 (didn't plan for a -1)
           iPlaySpeed = 1;
-        if (iPlaySpeed > 32 || iPlaySpeed < -32)
+        if (iPlaySpeed > g_advancedSettings.m_maxPlayerForwardRate || iPlaySpeed < -g_advancedSettings.m_maxPlayerForwardRate)
           iPlaySpeed = 1;
 
         SetPlaySpeed(iPlaySpeed);

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -112,6 +112,7 @@ void CAdvancedSettings::Initialize()
   m_DXVANoDeintProcForProgressive = false;
   m_videoFpsDetect = 1;
   m_videoDefaultLatency = 0.0;
+  m_maxPlayerForwardRate = 32;
 
   m_musicUseTimeSeeking = true;
   m_musicTimeSeekForward = 10;
@@ -773,6 +774,8 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   XMLUtils::GetFloat(pRootElement,"sleepbeforeflip", m_sleepBeforeFlip, 0.0f, 1.0f);
   XMLUtils::GetBoolean(pRootElement,"virtualshares", m_bVirtualShares);
   XMLUtils::GetUInt(pRootElement, "packagefoldersize", m_addonPackageFolderSize);
+
+  XMLUtils::GetInt(pRootElement, "maxplayerforwardrate", m_maxPlayerForwardRate, 1, 32);
 
   //Tuxbox
   pElement = pRootElement->FirstChildElement("tuxbox");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -311,6 +311,7 @@ class CAdvancedSettings
     bool m_GLRectangleHack;
     int m_iSkipLoopFilter;
     float m_ForcedSwapTime; /* if nonzero, set's the explicit time in ms to allocate for buffer swap */
+    int m_maxPlayerForwardRate; /* limit seek speed for player */
 
     bool m_AllowD3D9Ex;
     bool m_ForceD3D9Ex;


### PR DESCRIPTION
Hi,
Limiting forward/backward seek speed according to settings (new option) in advancedsettings.xml.
Seeking at more than 4 times of playspeed on SMB-shares, don't work very well for us.

I just wonder if the speed setting is video only (because i put it into video-subtag of advancedsettings)?

Greets wolfi
