### PR TITLE
GUIScrollBarControl: fix onright/ondown navigation

### DIFF
--- a/xbmc/guilib/GUIScrollBarControl.cpp
+++ b/xbmc/guilib/GUIScrollBarControl.cpp
@@ -143,7 +143,7 @@ bool CGUIScrollBar::Move(int numSteps)
 {
   if (numSteps < 0 && m_offset == 0) // we are at the beginning - can't scroll up/left anymore
     return false;
-  if (numSteps > 0 && m_offset == m_numItems - m_pageSize) // we are at the end - we can't scroll down/right anymore
+  if (numSteps > 0 && m_offset == std::max(m_numItems - m_pageSize, 0)) // we are at the end - we can't scroll down/right anymore
     return false;
 
   m_offset += numSteps * m_pageSize;


### PR DESCRIPTION
when master control doesn't have enough items to fill at least 1 page.
This is a fix from pieh merged into Frodo 12.2. Would be nice to have it in here too.
Thx.
